### PR TITLE
Several bug fixes and improvements.

### DIFF
--- a/compose/nginx.conf
+++ b/compose/nginx.conf
@@ -11,6 +11,7 @@ events {
 error_log               /dev/stderr info;
 
 env NXS_BASEDIR;
+env NXS_LOG_LEVEL;
 
 http {
     include             mime.types;
@@ -23,6 +24,9 @@ http {
     client_body_timeout 60;
     send_timeout        60;
     server_tokens       off;
+
+    client_body_buffer_size 32m;
+    client_max_body_size 128m;
 
     access_log          /dev/stdout;
 

--- a/src/core/nxs.c
+++ b/src/core/nxs.c
@@ -187,6 +187,11 @@ _nxs_decl_err(nxs_t *nxs, int level, const char *file, int line,
 	va_end(ap);
 
 	_app_log(level, file, line, func, "%s", s);
+	if (__predict_false(!nxs)) {
+		// Unit tests only.
+		free(s);
+		return;
+	}
 
 	if (level & LOG_EMSG) {
 		(void)asprintf(&msg, "%s: %s", s, strerror(error));
@@ -552,7 +557,7 @@ out:
 __dso_public int
 nxs_index_remove(nxs_index_t *idx, nxs_doc_id_t doc_id)
 {
-	if (idx_dtmap_sync(idx) == -1 || idx_dtmap_remove(idx, doc_id) == -1) {
+	if (idx_dtmap_remove(idx, doc_id) == -1) {
 		nxs_error_checkpoint(idx->nxs);
 		return -1;
 	}

--- a/src/index/idxmap.c
+++ b/src/index/idxmap.c
@@ -58,7 +58,7 @@ int
 idx_db_open(idxmap_t *idxmap, const char *path, bool *created)
 {
 	struct stat st;
-	int fd, retry = 3;
+	int fd, retry = 10;
 again:
 	fd = open(path, O_RDWR | O_CLOEXEC);
 	if (__predict_false(fd == -1 && errno == ENOENT)) {

--- a/src/index/idxterm.c
+++ b/src/index/idxterm.c
@@ -123,7 +123,6 @@ idxterm_create(const char *token, const size_t len, const size_t offset)
 	ASSERT(len <= UINT16_MAX);
 	term->value_len = len;
 
-	app_dbgx("term %p [%s]", term, term->value);
 	return term;
 }
 
@@ -216,7 +215,7 @@ idxterm_fuzzysearch(nxs_index_t *idx, const char *value, size_t len)
 	uint64_t term_total = 0;
 	unsigned total_len;
 
-	/* XXX: inefficient */
+	/* XXX: inefficient (alloc + copy) */
 	total_len = offsetof(idxterm_t, value[(unsigned)len + 1]);
 	if ((search_token = malloc(total_len)) == NULL) {
 		return NULL;
@@ -321,10 +320,9 @@ idxterm_add_doc(idxterm_t *term, nxs_doc_id_t doc_id)
 	return 0;
 }
 
-int
+void
 idxterm_del_doc(idxterm_t *term, nxs_doc_id_t doc_id)
 {
 	roaring_bitmap_remove(term->doc_bitmap, doc_id);
 	app_dbgx("unlinking doc %"PRIu64" from term %u", doc_id, term->id);
-	return 0;
 }

--- a/src/index/index.h
+++ b/src/index/index.h
@@ -113,7 +113,7 @@ idxterm_t *	idxterm_lookup(nxs_index_t *, const char *, size_t);
 idxterm_t *	idxterm_lookup_by_id(nxs_index_t *, nxs_term_id_t);
 idxterm_t *	idxterm_fuzzysearch(nxs_index_t *, const char *, size_t);
 int		idxterm_add_doc(idxterm_t *, nxs_doc_id_t);
-int		idxterm_del_doc(idxterm_t *, nxs_doc_id_t);
+void		idxterm_del_doc(idxterm_t *, nxs_doc_id_t);
 void		idxterm_incr_total(nxs_index_t *, const idxterm_t *, unsigned);
 void		idxterm_decr_total(nxs_index_t *, const idxterm_t *, unsigned);
 uint64_t	idxterm_get_total(nxs_index_t *, const idxterm_t *);
@@ -140,10 +140,13 @@ void		idx_terms_close(nxs_index_t *);
 /*
  * Document-terms index interface.
  */
+
+#define	DTMAP_PARTIAL_SYNC	(0x01)
+
 int		idx_dtmap_open(nxs_index_t *, const char *);
 int		idx_dtmap_add(nxs_index_t *, nxs_doc_id_t, tokenset_t *);
 int		idx_dtmap_remove(nxs_index_t *, nxs_doc_id_t);
-int		idx_dtmap_sync(nxs_index_t *);
+int		idx_dtmap_sync(nxs_index_t *, unsigned);
 void		idx_dtmap_close(nxs_index_t *);
 
 uint64_t	idx_get_token_count(const nxs_index_t *);

--- a/src/index/storage.h
+++ b/src/index/storage.h
@@ -91,6 +91,7 @@ static_assert(sizeof(idxterms_hdr_t) % 8 == 0, "alignment guard");
  *
  * => Invariant: document ID is always 64-bit aligned.
  * => Document ID is atomically set to zero on deletion.
+ * => A marker with document ID and zero length is used to notify deletion.
  *
  * CAUTION: All values must be converted to big-endian for storage.
  */

--- a/src/index/terms.c
+++ b/src/index/terms.c
@@ -282,8 +282,8 @@ again:
 			}
 
 			/*
-			 * Race condition: the term was inserted concurrently,
-			 * therefore just using the existing term.
+			 * Race condition: another worker inserted the term
+			 * before we acquired the lock, so just use it.
 			 */
 			token->idxterm = result_term;
 			tokenset_moveback(tokens, token);

--- a/src/query/search.c
+++ b/src/query/search.c
@@ -85,7 +85,8 @@ nxs_index_search(nxs_index_t *idx, nxs_params_t *params,
 	/*
 	 * Sync the latest updates to the index.
 	 */
-	if (idx_terms_sync(idx) == -1 || idx_dtmap_sync(idx) == -1) {
+	if (idx_terms_sync(idx) == -1 ||
+	    idx_dtmap_sync(idx, DTMAP_PARTIAL_SYNC) == -1) {
 		return NULL;
 	}
 

--- a/src/tests/helpers.c
+++ b/src/tests/helpers.c
@@ -166,7 +166,7 @@ run_with_index(const char *terms_testdb_path, const char *dtmap_testdb_path,
 		ret = idx_terms_sync(&idx);
 		assert(ret == 0);
 
-		ret = idx_dtmap_sync(&idx);
+		ret = idx_dtmap_sync(&idx, 0);
 		assert(ret == 0);
 	}
 

--- a/src/tests/t_index_remove.c
+++ b/src/tests/t_index_remove.c
@@ -83,7 +83,7 @@ run_removal_test(void)
 	/*
 	 * Sync the other descriptor and verify there.
 	 */
-	ret = idx_dtmap_sync(alt_idx);
+	ret = idx_dtmap_sync(alt_idx, 0);
 	assert(ret == 0);
 	verify_docs(alt_idx);
 
@@ -96,7 +96,7 @@ run_removal_test(void)
 	idx = nxs_index_open(nxs, "__test-idx-1");
 	assert(idx);
 
-	assert(idx_terms_sync(idx) == 0 && idx_dtmap_sync(idx) == 0);
+	assert(idx_terms_sync(idx) == 0 && idx_dtmap_sync(idx, 0) == 0);
 	verify_docs(idx);
 
 	nxs_index_close(idx);

--- a/src/tests/t_mmrw.c
+++ b/src/tests/t_mmrw.c
@@ -72,11 +72,36 @@ run_integer_tests(void)
 	assert(mmrw_fetch64(&mm, &u64) == 8 && u64 == 0x200040010004018UL);
 }
 
+static void
+run_seek_tests(void)
+{
+	char v, buf[] = { 0, 1, 2, 3, 4, 5 };
+	size_t offset;
+	mmrw_t mm;
+
+	mmrw_init(&mm, buf, sizeof(buf));
+
+	assert(mmrw_advance(&mm, 3) == 3);
+	offset = MMRW_GET_OFFSET(&mm);
+
+	assert(mmrw_fetch(&mm, &v, sizeof(v)) == 1);
+	assert(v == 3);
+
+	assert(mmrw_advance(&mm, 1) == 1);
+	assert(mmrw_fetch(&mm, &v, sizeof(v)) == 1);
+	assert(v == 5);
+
+	assert(mmrw_seek(&mm, offset) == (ssize_t)offset);
+	assert(mmrw_fetch(&mm, &v, sizeof(v)) == 1);
+	assert(v == 3);
+}
+
 int
 main(void)
 {
 	run_basic_tests();
 	run_integer_tests();
+	run_seek_tests();
 	puts("OK");
 	return 0;
 }

--- a/src/utils/log.c
+++ b/src/utils/log.c
@@ -8,11 +8,13 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
+#include <unistd.h>
 #include <errno.h>
 
 #include "utils.h"
 
-int	app_log_level = LOG_NOTICE;
+int		app_log_level = LOG_NOTICE;
+static pid_t	app_pid;
 
 int
 app_set_loglevel(const char *level)
@@ -28,6 +30,8 @@ app_set_loglevel(const char *level)
 		{ "INFO",	LOG_INFO	},
 		{ "DEBUG",	LOG_DEBUG	}
 	};
+
+	app_pid = getpid();
 
 	for (unsigned i = 0; i < __arraycount(log_levels); i++) {
 		if (strcasecmp(log_levels[i].name, level) == 0) {
@@ -50,7 +54,7 @@ _app_log(int level, const char *file, int line,
 	if (level & LOG_EMSG) {
 		err = errno;
 	}
-	snprintf(fileline, sizeof(fileline), "%s:%d", file, line);
+	snprintf(fileline, sizeof(fileline), "%u:%s:%d", app_pid, file, line);
 	ret = snprintf(p, size, "%-25s :: %s: ", fileline, func);
 	p += ret, size -= ret;
 

--- a/src/utils/mmrw.c
+++ b/src/utils/mmrw.c
@@ -41,6 +41,17 @@ mmrw_advance(mmrw_t *mm, size_t len)
 }
 
 ssize_t
+mmrw_seek(mmrw_t *mm, size_t offset)
+{
+	if (offset >= mm->length) {
+		return -1;
+	}
+	mm->curptr = (uint8_t *)mm->baseptr + offset;
+	mm->remaining = mm->length - offset;
+	return offset;
+}
+
+ssize_t
 mmrw_fetch(mmrw_t *mm, void *buf, size_t len)
 {
 	const void *p = mm->curptr;

--- a/src/utils/mmrw.h
+++ b/src/utils/mmrw.h
@@ -21,6 +21,8 @@ typedef struct {
 void		mmrw_init(mmrw_t *, void *, size_t);
 
 ssize_t		mmrw_advance(mmrw_t *, size_t);
+ssize_t		mmrw_seek(mmrw_t *, size_t);
+
 ssize_t		mmrw_fetch(mmrw_t *, void *, size_t);
 ssize_t		mmrw_store(mmrw_t *, const void *, size_t);
 

--- a/svc-src/nxsearch_svc.lua
+++ b/svc-src/nxsearch_svc.lua
@@ -38,10 +38,16 @@ end
 local function get_http_body(raise_err)
   ngx.req.read_body() -- fetch the body data
   local data = ngx.req.get_body_data()
-  if not data and raise_err then
-    ngx.status = ngx.HTTP_BAD_REQUEST
-    ngx.say("no data")
-    ngx.exit(ngx.HTTP_BAD_REQUEST)
+  if not data then
+    -- TODO: local file_name = ngx.req.get_body_file()
+    if raise_err then
+      local err = "no data or the data is too large"
+      ngx.log(ngx.INFO, string.format("get_http_body: %s", err))
+
+      ngx.status = ngx.HTTP_BAD_REQUEST
+      ngx.say(errmsg)
+      ngx.exit(ngx.HTTP_BAD_REQUEST)
+    end
   end
   return data
 end
@@ -52,6 +58,9 @@ local function set_http_error(err)
     ["code"] = err.code,
     ["msg"] = err.msg,
   }}))
+  ngx.log(ngx.INFO, string.format(
+    "nxsearch error: %s (code %u)", err.msg, err.code
+  ))
   return ngx.exit(ngx.HTTP_BAD_REQUEST)
 end
 


### PR DESCRIPTION
- Synchronization bug: idx_terms_sync() and idx_dtmap_sync() must be called with the dtmap lock held during the document addition/removal.

- idx_db_open: retry a little bit harder if there are concurrent calls.

- nxsearch_svc: significantly increase the HTTP body buffer sizes to support larger documents; also, improve error logging on the Lua side.

- Include the PID in the log lines and some other minor/misc fixes.