### PR TITLE
Add support for query logics (part I).

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -105,6 +105,7 @@ OBJS+=		core/filters_lua.o
 OBJS+=		core/params.o
 OBJS+=		core/results.o
 
+OBJS+=		query/expr.o
 OBJS+=		query/search.o
 
 OBJS+=		index/idxmap.o

--- a/src/algo/deque.c
+++ b/src/algo/deque.c
@@ -130,3 +130,21 @@ deque_push(deque_t *dq, void *elm)
 
 	return 0;
 }
+
+void **
+deque_get_array(deque_t *dq)
+{
+	return &dq->elements[dq->start];
+}
+
+void *
+deque_get(deque_t *dq, unsigned i)
+{
+	return dq->elements[dq->start + i];
+}
+
+size_t
+deque_count(const deque_t *dq)
+{
+	return dq->count;
+}

--- a/src/algo/deque.h
+++ b/src/algo/deque.h
@@ -17,4 +17,8 @@ int		deque_push(deque_t *, void *);
 void *		deque_pop_front(deque_t *);
 void *		deque_pop_back(deque_t *);
 
+void **		deque_get_array(deque_t *);
+void *		deque_get(deque_t *, unsigned);
+size_t		deque_count(const deque_t *);
+
 #endif

--- a/src/core/results.c
+++ b/src/core/results.c
@@ -128,7 +128,7 @@ nxs_resp_tojson(nxs_resp_t *resp, size_t *len)
 int
 nxs_resp_addresult(nxs_resp_t *resp, const idxdoc_t *doc, float score)
 {
-	result_entry_t*entry;
+	result_entry_t *entry;
 
 	entry = rhashmap_get(resp->doc_map, &doc->id, sizeof(nxs_doc_id_t));
 	if (entry) {

--- a/src/core/tokenizer.h
+++ b/src/core/tokenizer.h
@@ -17,8 +17,9 @@
 #include "rhashmap.h"
 #include "filters.h"
 
-#define	TOKENSET_STAGE		(0x1)
-#define	TOKENSET_FUZZYMATCH	(0x2)
+#define	TOKENSET_STAGE		(0x01)
+#define	TOKENSET_TRIM		(0x02)
+#define	TOKENSET_FUZZYMATCH	(0x10)
 
 typedef struct token {
 	/*

--- a/src/index/idxdoc.c
+++ b/src/index/idxdoc.c
@@ -57,16 +57,18 @@ idxdoc_destroy(nxs_index_t *idx, idxdoc_t *doc)
 	rhashmap_del(idx->dt_map, &doc->id, sizeof(nxs_doc_id_t));
 	TAILQ_REMOVE(&idx->dt_list, doc, entry);
 	idx->dt_count--;
-	app_dbgx("doc ID %"PRIu64", %p, dt_count %lu", doc->id, doc, idx->dt_count);
+	app_dbgx("doc ID %"PRIu64" (%p), total %lu",
+	    doc->id, doc, idx->dt_count);
 	free(doc);
 }
 
 idxdoc_t *
 idxdoc_lookup(nxs_index_t *idx, nxs_doc_id_t doc_id)
 {
-	idxdoc_t *doc = rhashmap_get(idx->dt_map, &doc_id, sizeof(nxs_doc_id_t));
-	app_dbgx("doc ID %"PRIu64" => %p (ID == %"PRIu64"; dt_count %lu)", doc_id, doc,
-	    doc ? doc->id : 0, idx->dt_count);
+	idxdoc_t *doc;
+
+	doc = rhashmap_get(idx->dt_map, &doc_id, sizeof(nxs_doc_id_t));
+	app_dbgx("doc ID %"PRIu64" => %p", doc_id, doc);
 	return doc;
 }
 

--- a/src/query/expr.c
+++ b/src/query/expr.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2023 Mindaugas Rasiukevicius <rmind at noxt eu>
+ * All rights reserved.
+ *
+ * Use is subject to license terms, as specified in the LICENSE file.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "index.h"
+#include "tokenizer.h"
+#include "deque.h"
+#include "expr.h"
+#include "utils.h"
+
+////////////////////////////////////////////////////////////////////////////
+
+query_t *
+query_create(nxs_index_t *idx)
+{
+	query_t *q;
+
+	if ((q = calloc(1, sizeof(query_t))) == NULL) {
+		return NULL;
+	}
+	if ((q->tokens = tokenset_create()) == NULL) {
+		free(q);
+		return NULL;
+	}
+	q->idx = idx;
+	return q;
+}
+
+void
+query_destroy(query_t *q)
+{
+	if (q->root) {
+		expr_destroy(q->root);
+	}
+	tokenset_destroy(q->tokens);
+	free(q);
+}
+
+#if 0
+void
+query_prepare(query_t *q, unsigned flags)
+{
+	tokenset_resolve(q->tokens, q->idx, TOKENSET_TRIM | flags);
+}
+#endif
+
+////////////////////////////////////////////////////////////////////////////
+
+expr_t *
+expr_create(query_t *q, expr_type_t type)
+{
+	expr_t *expr;
+
+	expr = calloc(1, sizeof(expr_t));
+	if (!expr) {
+		return NULL;
+	}
+	expr->type = type;
+	expr->query = q;
+
+	if (expr->type != EXPR_VAL_TOKEN) {
+		expr->elements = deque_create(0, 0);
+		if (!expr->elements) {
+			free(expr);
+			return NULL;
+		}
+	}
+	return expr;
+}
+
+#if 0
+int
+expr_set_token(expr_t *expr, const char *value, size_t len)
+{
+	query_t *q = expr->query;
+	filter_action_t action;
+	token_t *token;
+
+	ASSERT(expr->type == EXPR_VAL_TOKEN);
+
+	/*
+	 * Create a new token and run the filter pipeline.
+	 */
+	token = token_create(value, len);
+	if (__predict_false(token == NULL)) {
+		return -1;
+	}
+
+	action = filter_pipeline_run(q->idx->fp, &token->buffer);
+	if (__predict_false(action != FILT_MUTATION)) {
+		ASSERT(action == FILT_DISCARD || action == FILT_ERROR);
+		token_destroy(token);
+		if (action == FILT_ERROR) {
+			return -1;
+		}
+		return 0;
+	}
+	expr->token = token;
+	return 0;
+}
+#endif
+
+int
+expr_add_element(expr_t *expr, expr_t *elm)
+{
+	ASSERT(expr->type != EXPR_VAL_TOKEN);
+	return deque_push(expr->elements, elm);
+}
+
+void
+expr_destroy(expr_t *expr)
+{
+	deque_t *gc;
+
+	/*
+	 * G/C list for the expressions.  Begin with itself.
+	 */
+	gc = deque_create(0, 0);
+	deque_push(gc, expr);
+
+	/*
+	 * Deep-walk and G/C all expressions.
+	 */
+	while ((expr = deque_pop_back(gc)) != NULL) {
+		unsigned nitems;
+
+		if (expr->type == EXPR_VAL_TOKEN) {
+			ASSERT(expr->token);
+			free(expr);
+			continue;
+		}
+
+		nitems = deque_count(expr->elements);
+		for (unsigned i = 0; i < nitems; i++) {
+			expr_t *subexpr = deque_get(expr->elements, i);
+			deque_push(gc, subexpr);
+		}
+		deque_destroy(expr->elements);
+		free(expr);
+	}
+	deque_destroy(gc);
+}

--- a/src/query/expr.h
+++ b/src/query/expr.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Mindaugas Rasiukevicius <rmind at noxt eu>
+ * All rights reserved.
+ *
+ * Use is subject to license terms, as specified in the LICENSE file.
+ */
+
+#ifndef _EXPR_H_
+#define _EXPR_H_
+
+typedef struct query query_t;
+typedef struct expr expr_t;
+
+typedef enum {
+	// Values:
+	EXPR_VAL_TOKEN,
+	// Operations:
+	EXPR_OP_AND,
+	EXPR_OP_OR,
+	EXPR_OP_NOT,
+} expr_type_t;
+
+struct query {
+	nxs_index_t *		idx;
+	tokenset_t *		tokens;
+	expr_t *		root;
+};
+
+struct expr {
+	expr_type_t		type;
+	query_t *		query;
+	union {
+		token_t *	token;
+		deque_t *	elements;
+	};
+};
+
+query_t *	query_create(nxs_index_t *);
+void		query_destroy(query_t *);
+void		query_prepare(query_t *, unsigned);
+
+expr_t *	expr_create(query_t *, expr_type_t);
+int		expr_set_token(expr_t *, const char *, size_t);
+int		expr_add_element(expr_t *, expr_t *);
+void		expr_destroy(expr_t *);
+
+#endif

--- a/src/tests/helpers.h
+++ b/src/tests/helpers.h
@@ -22,14 +22,15 @@ typedef struct {
 	float		value[2];
 } test_score_t;
 
-#define	END_TEST_SCORE	{ 0, { 0, 0 } }
+#define	END_TEST_SCORE		{ 0, { 0, 0 } }
+#define	DOC_ID_ONLY(id)		{ (id), { -1, -1 } }
 
 typedef struct {
 	const test_doc_t *docs;
 	unsigned	doc_count;
 	const char *	query;
 	test_score_t	scores[];
-} test_score_case_t;
+} test_search_case_t;
 
 char *		get_tmpdir(void);
 char *		get_tmpfile(const char *);
@@ -40,6 +41,6 @@ tokenset_t *	get_test_tokenset(const char *[], size_t, bool);
 
 void		run_with_index(const char *, const char *, bool, test_func_t);
 
-void		test_index_search(const test_score_case_t *);
+void		test_index_search(const test_search_case_t *);
 
 #endif

--- a/src/tests/t_querylogic.c
+++ b/src/tests/t_querylogic.c
@@ -1,0 +1,62 @@
+/*
+ * Unit test: query logic.
+ * This code is in the public domain.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "nxs.h"
+#include "index.h"
+#include "helpers.h"
+#include "utils.h"
+
+static const test_doc_t docs[] = {
+	{ 1, "Textbook about Erlang in Linux environment" },
+	{ 2, "Unix Shell scripting textbook" },
+	{ 3, "Erlang and Python examples" },
+	{ 4, "Textbook about Python using Linux and Windows" },
+	{ 5, "All but NOT: Textbook Erlang Python Shell Linux Unix Java" },
+	{ 6, "All keywords: Textbook Erlang Python Shell Linux Unix" },
+};
+
+#if 0
+static const test_search_case_t test_case_1 = {
+	.docs = docs, .doc_count = __arraycount(docs),
+	.query = "textbook AND (Erlang OR Python OR Shell) AND "
+	         "(Linux OR Unix) AND NOT (Windows OR Java)",
+	.scores = {
+		DOC_ID_ONLY(1),
+		DOC_ID_ONLY(2),
+		DOC_ID_ONLY(6),
+		END_TEST_SCORE
+	}
+};
+#endif
+
+static const test_search_case_t test_case_2 = {
+	.docs = docs, .doc_count = __arraycount(docs),
+	.query = "unix",
+	.scores = {
+		DOC_ID_ONLY(2),
+		DOC_ID_ONLY(5),
+		DOC_ID_ONLY(6),
+		END_TEST_SCORE
+	}
+};
+
+static const test_search_case_t *test_cases[] = {
+	/* &test_case_1, */ &test_case_2
+};
+
+int
+main(void)
+{
+	for (unsigned i = 0; i < __arraycount(test_cases); i++) {
+		test_index_search(test_cases[i]);
+	}
+	puts("OK");
+	return 0;
+}

--- a/src/tests/t_scoring.c
+++ b/src/tests/t_scoring.c
@@ -32,7 +32,7 @@ static const test_doc_t docs_1[] = {
 static_assert(DOG_TFIDF_SCORE > FOX_TFIDF_SCORE, "logic guard");
 static_assert(DOG_BM25_SCORE > FOX_BM25_SCORE, "logic guard");
 
-static const test_score_case_t test_case_1 = {
+static const test_search_case_t test_case_1 = {
 	/*
 	 * Basic search: verify the expected score.
 	 */
@@ -43,7 +43,7 @@ static const test_score_case_t test_case_1 = {
 	}
 };
 
-static const test_score_case_t test_case_2 = {
+static const test_search_case_t test_case_2 = {
 	/*
 	 * Equal scores for each document.
 	 */
@@ -55,7 +55,7 @@ static const test_score_case_t test_case_2 = {
 	}
 };
 
-static const test_score_case_t test_case_3 = {
+static const test_search_case_t test_case_3 = {
 	/*
 	 * Scores for each term should be summed.
 	 */
@@ -77,7 +77,7 @@ static const test_doc_t docs_2[] = {
 	{ 2, "cat cat dog" },
 };
 
-static const test_score_case_t test_case_4 = {
+static const test_search_case_t test_case_4 = {
 	/*
 	 * TF: Documents matching more terms should have higher score.
 	 */
@@ -96,7 +96,7 @@ static const test_doc_t docs_3[] = {
 	{ 4, "cat dog rat bat" },
 };
 
-static const test_score_case_t test_case_5 = {
+static const test_search_case_t test_case_5 = {
 	/*
 	 * Documents matching more different terms (variety) should
 	 * have higher score.
@@ -117,7 +117,7 @@ static const test_doc_t docs_4[] = {
 	{ 3, "aa bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb" },
 };
 
-static const test_score_case_t test_case_6 = {
+static const test_search_case_t test_case_6 = {
 	/*
 	 * TF bound for term saturation (BM25): many matches of the same
 	 * term in the given document should have a bound.  BM25 is expected
@@ -143,7 +143,7 @@ static const test_doc_t docs_5[] = {
 	{ 3, "cats cats dogs" },	// only 2x cats, same length
 };
 
-static const test_score_case_t test_case_7 = {
+static const test_search_case_t test_case_7 = {
 	/*
 	 * Document length (BM25): matches in shorter documents
 	 * should give higher score.  No difference for TF-IDF.
@@ -157,7 +157,7 @@ static const test_score_case_t test_case_7 = {
 	}
 };
 
-static const test_score_case_t *test_cases[] = {
+static const test_search_case_t *test_cases[] = {
 	&test_case_1, &test_case_2, &test_case_3, &test_case_4,
 	&test_case_5, &test_case_6, &test_case_7
 };


### PR DESCRIPTION
- Add query_t and expr_t structures for the intermediate representation.

- Handle the query logic and the respective document score computation.

- tokenset_resolve: introduce the TOKENSET_TRIM flag; this function is basically used either for adding a document (TOKENSET_STAGE set) or for searching (TOKENSET_TRIM set).

- ranking (tf_idf / bm25): use negative values to indicate that the score should be ignored due to concurrent removal of a document. Also, make the tests more robust by verifying doc_count and adl which might slide into 0 if there is a race condition where all documents get concurrently removed.