### PR TITLE
Add support for query logics (part II).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@
 *.a
 *.so
 
+*/query/scan.c
+*/query/grammar.c
+*/query/grammar.h
+*/query/grammar.out
+
 .DS_Store
 
 compose/openapi.json

--- a/compose/svc.Dockerfile
+++ b/compose/svc.Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -y && \
     apt-get install -y build-essential libtool libtool-bin gdb && \
     apt-get install -y pkg-config cmake debhelper unzip libxml2-utils && \
     apt-get install -y libjemalloc-dev libicu-dev libstemmer-dev && \
-    apt-get install -y luajit libluajit-5.1-dev lua-cjson
+    apt-get install -y re2c lemon luajit libluajit-5.1-dev lua-cjson
 
 WORKDIR /nxsearch
 ENV NXS_BASEDIR=/nxsearch

--- a/src/Makefile
+++ b/src/Makefile
@@ -23,7 +23,7 @@ endif
 CFLAGS+=	-std=gnu11 -O2 -g -Wall -Wextra -Werror
 CFLAGS+=	-D_POSIX_C_SOURCE=200809L
 
-CFLAGS+=	-I core/ -I index/ -I algo/ -I utils/
+CFLAGS+=	-I core/ -I index/ -I algo/ -I query/ -I utils/
 
 #
 # Extended warning flags.
@@ -44,6 +44,8 @@ ifeq ($(CC),gcc)
 CFLAGS+=	-Wa,--fatal-warnings -Wl,--fatal-warnings
 endif
 ifeq ($(CC),clang)
+# NOTE: Manually aligned pointers in the memory-mapped files.
+CFLAGS+=	-Wno-address-of-packed-member -Wno-atomic-alignment
 CFLAGS+=	-flto
 LDFLAGS+=	-flto
 endif
@@ -106,6 +108,7 @@ OBJS+=		core/params.o
 OBJS+=		core/results.o
 
 OBJS+=		query/expr.o
+OBJS+=		query/query.o
 OBJS+=		query/search.o
 
 OBJS+=		index/idxmap.o

--- a/src/core/tokenizer.h
+++ b/src/core/tokenizer.h
@@ -54,14 +54,17 @@ typedef struct {
 	unsigned		seen;
 } tokenset_t;
 
+token_t *	token_create(const char *, size_t);
+void		token_destroy(token_t *);
+
 tokenset_t *	tokenset_create(void);
-void		tokenset_add(tokenset_t *, token_t *);
+token_t *	tokenset_add(tokenset_t *, token_t *);
 void		tokenset_moveback(tokenset_t *, token_t *);
 void		tokenset_resolve(tokenset_t *, nxs_index_t *, unsigned);
 void		tokenset_destroy(tokenset_t *);
 
-token_t *	token_create(const char *, size_t);
-void		token_destroy(token_t *);
+int		tokenize_value(filter_pipeline_t *, tokenset_t *,
+		    const char *, size_t, token_t **);
 tokenset_t *	tokenize(filter_pipeline_t *, nxs_params_t *,
 		    const char *, size_t);
 

--- a/src/query/expr.h
+++ b/src/query/expr.h
@@ -8,40 +8,35 @@
 #ifndef _EXPR_H_
 #define _EXPR_H_
 
-typedef struct query query_t;
-typedef struct expr expr_t;
+struct token;
 
 typedef enum {
 	// Values:
 	EXPR_VAL_TOKEN,
-	// Operations:
+	// Operators:
 	EXPR_OP_AND,
 	EXPR_OP_OR,
 	EXPR_OP_NOT,
 } expr_type_t;
 
-struct query {
-	nxs_index_t *		idx;
-	tokenset_t *		tokens;
-	expr_t *		root;
-};
+#define	EXPR_IS_OPERATOR(t)	((t) != EXPR_VAL_TOKEN)
 
-struct expr {
+typedef struct expr {
 	expr_type_t		type;
-	query_t *		query;
-	union {
-		token_t *	token;
-		deque_t *	elements;
-	};
-};
 
-query_t *	query_create(nxs_index_t *);
-void		query_destroy(query_t *);
-void		query_prepare(query_t *, unsigned);
+	// EXPR_VAL_TOKEN:
+	char *			value;
+	struct token *		token;
 
-expr_t *	expr_create(query_t *, expr_type_t);
-int		expr_set_token(expr_t *, const char *, size_t);
-int		expr_add_element(expr_t *, expr_t *);
+	// EXPR_IS_OPERATOR:
+	unsigned		nitems;
+	struct expr *		elements[];
+} expr_t;
+
+expr_t *	expr_create(expr_type_t, unsigned);
 void		expr_destroy(expr_t *);
+
+expr_t *	expr_create_token(char *);
+expr_t *	expr_create_operator(expr_type_t, expr_t *, expr_t *);
 
 #endif

--- a/src/query/query.c
+++ b/src/query/query.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023 Mindaugas Rasiukevicius <rmind at noxt eu>
+ * All rights reserved.
+ *
+ * Use is subject to license terms, as specified in the LICENSE file.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "index.h"
+#include "tokenizer.h"
+#include "expr.h"
+#define	__NXS_PARSER_PRIVATE
+#include "query.h"
+#include "utils.h"
+
+query_t *
+query_create(nxs_index_t *idx)
+{
+	query_t *q;
+
+	if ((q = calloc(1, sizeof(query_t))) == NULL) {
+		return NULL;
+	}
+	if ((q->tokens = tokenset_create()) == NULL) {
+		free(q);
+		return NULL;
+	}
+	q->idx = idx;
+	return q;
+}
+
+void
+query_destroy(query_t *q)
+{
+	if (q->root) {
+		expr_destroy(q->root);
+	}
+	tokenset_destroy(q->tokens);
+	free(q);
+}
+
+int
+query_prepare(query_t *q, unsigned flags)
+{
+	filter_pipeline_t *fp = q->idx->fp;
+	deque_t *iter;
+	expr_t *expr;
+	int ret = -1;
+
+	iter = deque_create(0, 0);
+	deque_push(iter, q->root);
+
+	/*
+	 * Deep-walk the expressions and obtain the tokens.
+	 */
+	while ((expr = deque_pop_back(iter)) != NULL) {
+		if (EXPR_IS_OPERATOR(expr->type)) {
+			for (unsigned i = 0; i < expr->nitems; i++) {
+				expr_t *subexpr = expr->elements[i];
+				deque_push(iter, subexpr);
+			}
+			continue;
+		}
+		ASSERT(expr->nitems == 0);
+
+		/*
+		 * Tokenize the value; if there is no term in use,
+		 * then the expr->token will remain NULL.
+		 */
+		if (tokenize_value(fp, q->tokens, expr->value,
+		    strlen(expr->value), &expr->token) == -1) {
+			goto err;
+		}
+	}
+
+	/* Resolve tokens to terms, removing those not in use. */
+	tokenset_resolve(q->tokens, q->idx, TOKENSET_TRIM | flags);
+	ret = 0;
+err:
+	deque_destroy(iter);
+	return ret;
+}

--- a/src/query/query.h
+++ b/src/query/query.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Mindaugas Rasiukevicius <rmind at noxt eu>
+ * All rights reserved.
+ *
+ * Use is subject to license terms, as specified in the LICENSE file.
+ */
+
+#ifndef _QUERY_H_
+#define _QUERY_H_
+
+struct query;
+typedef struct query query_t;
+
+#ifdef __NXS_PARSER_PRIVATE
+
+struct query {
+	nxs_index_t *	idx;
+
+	expr_t *	root;
+
+	/* Tokenset to be resolved. */
+	tokenset_t *	tokens;
+};
+
+#endif
+
+query_t *	query_create(nxs_index_t *);
+void		query_destroy(query_t *);
+int		query_prepare(query_t *, unsigned);
+
+#endif

--- a/src/tests/helpers.h
+++ b/src/tests/helpers.h
@@ -8,6 +8,7 @@
 
 #include "tokenizer.h"
 #include "index.h"
+#include "expr.h"
 
 typedef void (*test_func_t)(nxs_index_t *);
 

--- a/src/tests/t_querylogic.c
+++ b/src/tests/t_querylogic.c
@@ -25,14 +25,8 @@ static const test_doc_t docs[] = {
 #if 0
 static const test_search_case_t test_case_1 = {
 	.docs = docs, .doc_count = __arraycount(docs),
-	.query = "textbook AND (Erlang OR Python OR Shell) AND "
-	         "(Linux OR Unix) AND NOT (Windows OR Java)",
-	.scores = {
-		DOC_ID_ONLY(1),
-		DOC_ID_ONLY(2),
-		DOC_ID_ONLY(6),
-		END_TEST_SCORE
-	}
+	.query = "non-existant-term",  // empty results if unused terms
+	.scores = { END_TEST_SCORE }
 };
 #endif
 
@@ -47,8 +41,23 @@ static const test_search_case_t test_case_2 = {
 	}
 };
 
+#if 0
+static const test_search_case_t test_case_3 = {
+	.docs = docs, .doc_count = __arraycount(docs),
+	.query = "textbook AND (Erlang OR Python OR Shell) AND "
+	         "(Linux OR Unix) AND NOT (Windows OR Java)",
+	.scores = {
+		DOC_ID_ONLY(1),
+		DOC_ID_ONLY(2),
+		DOC_ID_ONLY(6),
+		END_TEST_SCORE
+	}
+};
+#endif
+
 static const test_search_case_t *test_cases[] = {
-	/* &test_case_1, */ &test_case_2
+	//&test_case_1, &test_case_2, &test_case_3,
+	&test_case_2
 };
 
 int

--- a/src/utils/utf8.c
+++ b/src/utils/utf8.c
@@ -219,8 +219,8 @@ utf8_subs_diacritics(utf8_ctx_t *ctx, strbuf_t *buf)
 {
 	UErrorCode ec = U_ZERO_ERROR;
 	uint16_t *ubuf = NULL;
+	int32_t len = -1, max_len;
 	size_t ulen;
-	int32_t len, max_len;
 
 	/*
 	 * Convert from UTF-8 to UTF-16: see the comments in the


### PR DESCRIPTION
- Add re2c and lemon dependencies (in preparation).

- tokenizer: introduce tokenize_value() and refactor a little bit.

- Introduce expr_create_operator()/expr_create_token() and refactor.

- Introduce query_prepare() to resolve tokens in the expression tree.

- run_query_logic: return without error if there are no terms in-use.

- utf8_subs_diacritics: fix a bug in error branch while here.